### PR TITLE
Creating a global property and setting the registration constant so u…

### DIFF
--- a/api/src/main/java/org/openmrs/module/registrationcore/RegistrationCoreConstants.java
+++ b/api/src/main/java/org/openmrs/module/registrationcore/RegistrationCoreConstants.java
@@ -86,6 +86,8 @@ public final class RegistrationCoreConstants {
 
 	public static final String GP_MPI_PIX_IDENTTIFIER_TYPE_UUID_LIST = "registrationcore.mpi.pixIdentifierTypeUuidList";
 
+	public static final String GP_BIOMETRICS_PERSON_IDENTIFIER_TYPE_UUID = "registrationcore.biometrics.personIdentifierTypeUuid";
+
 	public static final String GP_BIOMETRICS_IMPLEMENTATION = "registrationcore.biometrics.implementation";
 
 	public static final String GP_ERROR_HANDLER_IMPLEMENTATION = "registrationcore.errorHandler.implementation";

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -144,6 +144,14 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>${project.parent.artifactId}.biometrics.personIdentifierTypeUuid</property>
+		<defaultValue></defaultValue>
+		<description>
+			Specifies UUID of the identifier type that is used to store the biometric reference code
+		</description>
+	</globalProperty>
+	
+	<globalProperty>
 		<property>${project.parent.artifactId}.biometrics.implementation</property>
 		<defaultValue></defaultValue>
 		<description>


### PR DESCRIPTION
…sers can define the fingerprint Identifier Type UUID. This is referenced by the fingerprint fragments.