### PR TITLE
Disable MPI integration by default

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -105,7 +105,7 @@
 
 	<globalProperty>
 		<property>${project.parent.artifactId}.mpi.implementation</property>
-		<defaultValue>registrationcore.mpi.implementation.PixPdq</defaultValue>
+		<defaultValue></defaultValue>
 		<description>
 			Which MPI to should we connect to? Specify a Spring bean name, or leave blank to disable MPI integration
 		</description>


### PR DESCRIPTION
Change the default value of registrationcore.mpi.implementation from `registrationcore.mpi.implementation.PixPdq` to empty. This disables MPI sync on fresh installs and module restarts. Sites that want MPI can set the property to the desired name.