### PR TITLE
Suppress MPI sync AOP during patient import to prevent duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,64 +1,37 @@
-# This is a basic workflow to help you get started with Actions
+name: Build, Test & Publish
 
-name: CI
-
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
   release:
     types: [ created ]
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5.2.0
         with:
-          java-version: 8.0.232
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4
-        with:
-          maven-version: 3.6.3
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "github-packages",
-                "username": "${{ secrets.RELEASE_USERNAME }}",
-                "password": "${{ secrets.RELEASE_TOKEN }}"
-            }]
-          properties: |
-            [
-              { "maven.wagon.http.ssl.insecure": "true" },
-              { "maven.wagon.http.ssl.allowall": "true" },
-              { "maven.wagon.http.ssl.ignore.validity.dates": "true"}
-            ]
-          githubServer: false
-      - name: Build with Maven
-        run: mvn -P 'github-packages' install
+          java-version: '8'
+          distribution: zulu
+          cache: maven
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
+
+      - name: Build and test
+        run: mvn -B -P github-packages install
+
       - name: Publish package
-        run: mvn -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true -B deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         if: github.event_name == 'release' && github.event.action == 'created'
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
+        env:
+          RELEASE_USERNAME: ${{ github.actor }}
+          RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      RELEASE_USERNAME: ${{ github.actor }}
+      RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -32,6 +36,3 @@ jobs:
       - name: Publish package
         if: github.event_name == 'release' && github.event.action == 'created'
         run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
-        env:
-          RELEASE_USERNAME: ${{ github.actor }}
-          RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreServiceImpl.java
@@ -33,6 +33,7 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.santedb.mpiclient.aop.PatientSynchronizationAdvice;
 import org.openmrs.event.Event;
 import org.openmrs.event.EventMessage;
 import org.openmrs.module.idgen.IdentifierSource;
@@ -716,7 +717,12 @@ public class RegistrationCoreServiceImpl extends BaseOpenmrsService implements R
 			mpiPatient.addIdentifier(localId);
 		}
 
-		return patientService.savePatient(mpiPatient);
+		PatientSynchronizationAdvice.SUPPRESS.set(true);
+		try {
+			return patientService.savePatient(mpiPatient);
+		} finally {
+			PatientSynchronizationAdvice.SUPPRESS.set(false);
+		}
 	}
 
 	private boolean isBiometricEngineEnabled() {

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<namephoneticsVersion>1.4</namephoneticsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<xdsSenderVersion>2.2.1</xdsSenderVersion>
-		<mpiClientVersion>1.1.0</mpiClientVersion>
+		<mpiClientVersion>1.1.5-SNAPSHOT</mpiClientVersion>
 		<apacheHttpCoreVersion>4.4.9</apacheHttpCoreVersion>
 		<apacheHttpClientVersion>4.5</apacheHttpClientVersion>
 		<jodaTimeVersion>2.2</jodaTimeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<namephoneticsVersion>1.4</namephoneticsVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<xdsSenderVersion>2.2.1</xdsSenderVersion>
-		<mpiClientVersion>1.1.5-SNAPSHOT</mpiClientVersion>
+		<mpiClientVersion>1.1.8</mpiClientVersion>
 		<apacheHttpCoreVersion>4.4.9</apacheHttpCoreVersion>
 		<apacheHttpClientVersion>4.5</apacheHttpClientVersion>
 		<jodaTimeVersion>2.2</jodaTimeVersion>


### PR DESCRIPTION
## Summary

When `importMpiPatient()` saves a patient via `createImportedMpiPatient()`, the mpi-client `PatientSynchronizationAdvice` AOP fires and spawns a `PatientUpdateWorker`. This worker re-queries the MPI, discovers golden record `seealso` links, and triggers a second import — creating a duplicate local patient.

- Wrap the `savePatient()` call in `createImportedMpiPatient()` with `PatientSynchronizationAdvice.SUPPRESS` to skip the AOP during import
- The export back to MPI is already handled explicitly by `exportPatient()` at the end of `importMpiPatient()`, so the AOP-triggered export is redundant anyway
- Bump `mpiClientVersion` from `1.1.0` to `1.1.5-SNAPSHOT` to pick up the `SUPPRESS` ThreadLocal flag

Depends on IsantePlus/openmrs-module-mpi-client#60.